### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/createGitHubIssues.yaml
+++ b/.github/workflows/createGitHubIssues.yaml
@@ -6,6 +6,10 @@ on:
     paths:
       - ".codex/tasks/backlog.yaml"
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   create-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SPECTRADataSolutions/portal/security/code-scanning/3](https://github.com/SPECTRADataSolutions/portal/security/code-scanning/3)

To fix this issue, you need to explicitly define a `permissions` block within the workflow. Since this workflow creates GitHub issues, it requires `issues: write` permission while other permissions can remain set to `read` or omitted entirely. The `permissions` block should be added at the root of the workflow (applying to all jobs) or specifically to the `create-issues` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
